### PR TITLE
Sync agenda

### DIFF
--- a/java-project/src/fr/partipirate/discord/bots/congressus/commands/congressus/SyncAgendaCommand.java
+++ b/java-project/src/fr/partipirate/discord/bots/congressus/commands/congressus/SyncAgendaCommand.java
@@ -1,0 +1,34 @@
+package fr.partipirate.discord.bots.congressus.commands.congressus;
+
+import fr.partipirate.discord.bots.congressus.commands.ICommand;
+import fr.partipirate.discord.bots.congressus.common.congressus.SyncAgenda;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.api.entities.User;
+
+
+public class SyncAgendaCommand extends ACongressusCommand implements ICommand {
+
+	@Override
+	public String getKeyWord() {
+		return "agenda";
+	}
+
+	@Override
+	public boolean canDoCommand(User user, Guild guild) {
+		return true;
+	}
+
+	@Override
+	public void doCommand(User user, MessageChannel channel, Guild guild, String[] commandParts) {
+		String message = SyncAgenda.syncAgenda(guild);
+		if (message != null)
+			channel.sendMessage(message).complete();
+	}
+
+	@Override
+	public String getCommandHelp() {
+		return "Synchronise l'agenda Discord avec l'agenda Congressus sur le prochain mois";
+	}
+
+}

--- a/java-project/src/fr/partipirate/discord/bots/congressus/common/congressus/SyncAgenda.java
+++ b/java-project/src/fr/partipirate/discord/bots/congressus/common/congressus/SyncAgenda.java
@@ -1,0 +1,302 @@
+package fr.partipirate.discord.bots.congressus.common.congressus;
+
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.net.URL;
+import java.net.URLConnection;
+import java.sql.Timestamp;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import org.apache.commons.text.StringEscapeUtils;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+import fr.partipirate.discord.bots.congressus.commands.congressus.CongressusHelper;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.ScheduledEvent;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
+import net.dv8tion.jda.internal.managers.ScheduledEventManagerImpl;
+
+public class SyncAgenda {
+    
+    public static String syncAgenda(Guild guild){
+        /**
+         * Synchronize Congressus meetings with Discord events
+         */
+        long now = System.currentTimeMillis();
+		String congressusMeetingsUrl = CongressusHelper.getUrl() + "do_getMeetings.php?from=" + now + "&to=" + (now + 86400000L * 30);
+		
+		try {
+			URL url = new URL(congressusMeetingsUrl);
+			URLConnection connection = url.openConnection();
+			InputStreamReader sr = new InputStreamReader(connection.getInputStream());
+			StringWriter sw = new StringWriter();
+			
+			char[] buffer = new char[8192];
+			int nbRead;
+			
+			while ((nbRead = sr.read(buffer)) != -1) {
+				sw.write(buffer, 0, nbRead);
+			}
+
+			sr.close();
+			sw.close();
+
+			String json = sw.toString();
+
+			JSONObject object = (JSONObject) new JSONTokener(json).nextValue();
+			if (object.getInt("success") != 1)
+				return "Impossible de lister les réunions";
+
+			JSONArray congressusMeetings = object.getJSONArray("result");
+			List<ScheduledEvent> discordEvents = guild.getScheduledEvents();
+
+
+			createMissingEvents(congressusMeetings, discordEvents, guild);
+
+			
+
+			deleteOldEvents(congressusMeetings, discordEvents, guild);
+			
+			return "La liste des événements a été mise à jour";
+		}
+		catch(Exception e) {
+			for (StackTraceElement el: e.getStackTrace())
+				System.err.println(el);
+			return "Erreur pendant la mise à jour des événements : " + e.getMessage();
+		}
+    }
+    
+	protected static ScheduledEvent getEvent(JSONObject meeting, List<ScheduledEvent> discordEvents) {
+		/**
+		 * Look on all discord scheduled events if a meeting is already exists
+		 * The only unique value of a meeting is this ID, visible on meeting json or url
+		 * As we add url on event description, a meeting already exists if :
+		 * - Description contains the same URL as my meeting
+		 * - other ? …
+		 * Return null if not found
+		 */
+		
+		String url = meeting.getString("url");
+		for (ScheduledEvent event: discordEvents) {
+			if (event.getDescription().contains(url))
+				return event;
+		}
+
+		return null;
+	}
+
+	protected static void createMissingEvents(JSONArray congressusMeetings, List<ScheduledEvent> discordEvents, Guild guild) {
+		/* Create or update missing discord events */
+		for(int i = 0; i < congressusMeetings.length(); ++i) {
+			JSONObject meeting = congressusMeetings.getJSONObject(i);
+			createEvent(meeting, discordEvents, guild);
+		}
+	}
+
+	protected static GuildChannel getDiscordChannel(JSONObject meeting, Guild guild) {
+		/**
+		 * Find if meeting location is on a known channel
+		 * @return VoiceChannel or null
+		 */
+				
+		if (meeting.has("location") && meeting.getJSONObject("location").has("discord")) {
+			// look for discord channel
+			JSONObject locationDiscord = meeting.getJSONObject("location").getJSONObject("discord");
+
+			if (locationDiscord.has("vocal")) {
+				String chan = locationDiscord.getJSONObject("vocal").getString("title");
+				List<VoiceChannel> channels = guild.getVoiceChannelsByName(chan, true);
+
+				if (channels.size() > 0){
+					// channels found, we will use first
+					return channels.get(0);
+				}
+			}
+			
+			if (locationDiscord.has("text")) {
+				String chan = locationDiscord.getJSONObject("text").getString("title");
+				List<TextChannel> channels = guild.getTextChannelsByName(chan, true);
+				if (channels.size() > 0){
+					// channels found, we will use first
+					return channels.get(0);
+				}
+			}
+		}
+		return null;
+
+	}
+
+	protected static String getExternalLocation(JSONObject meeting) {
+		/**
+		 * Get external location of a meeting
+		 */
+
+		if (meeting.has("location")) {
+			JSONObject location = meeting.getJSONObject("location");
+			if (location.has("extra"))
+				return StringEscapeUtils.unescapeHtml4(location.getString("extra").split("\\n")[0]).trim();
+			if (location.has("type"))
+			return StringEscapeUtils.unescapeHtml4(location.getString("type")).trim();
+		}
+		return "Emplacement inconnu";
+	}
+
+	protected static String createDescription(JSONObject meeting) {
+		/**
+		 * Create description string from meeting
+		 */
+		String description = StringEscapeUtils.unescapeHtml4(meeting.getString("title"));
+		if (meeting.has("location") && meeting.getJSONObject("location").has("extra"))
+			description += "\n" + meeting.getJSONObject("location").getString("extra");
+
+		if (meeting.has("location") && meeting.getJSONObject("location").has("discord")) {
+			JSONObject discordLocation = meeting.getJSONObject("location").getJSONObject("discord");
+
+			if (discordLocation.has("vocal"))
+				description += "\nVocal : " + discordLocation.getJSONObject("vocal").get("title");	
+			if (discordLocation.has("text"))
+				description += "\nTexte : " + discordLocation.getJSONObject("text").get("title");	
+		}
+
+		description += "\n" + meeting.getString("url");
+
+		return description.trim();
+	}
+
+	protected static void createEvent(JSONObject meeting, List<ScheduledEvent> discordEvents, Guild guild) {
+		/**
+		 * Create or update a Discord event with datas from congressus meeting
+		 * 
+		 * JDA dont implement ScheduledEvents. If event updated, we need to delete/recreate event
+		 */
+
+		String title = meeting.getString("meetingTitle").trim();
+		ScheduledEvent event = getEvent(meeting, discordEvents);
+
+		String description = createDescription(meeting);
+		OffsetDateTime start = timestampToOffsetDateTime(meeting.getLong("start"));
+		OffsetDateTime end = timestampToOffsetDateTime(meeting.getLong("end"));
+
+		if (start.compareTo(OffsetDateTime.now()) <= 0) {
+			//System.out.println("Event '" + title + "' start in the past, it's forbidden");
+			return;
+		}
+
+		GuildChannel channel = getDiscordChannel(meeting, guild);
+		String externalLocation = getExternalLocation(meeting);
+
+		if (event != null) {
+			ScheduledEventManagerImpl eventManager = new ScheduledEventManagerImpl(event);
+			boolean updated = false;
+			if (!event.getName().equals(title)) {
+				eventManager.setName(title).complete();
+				updated = true;
+			}
+			if (!event.getDescription().equals(description)) {
+				eventManager.setDescription(description).complete();
+				updated = true;
+			}
+			if (channel != null) {
+				if (event.getChannel() != channel) {
+					eventManager.setLocation(channel).complete();
+					updated = true;
+				}
+			} else {
+				if (!event.getLocation().equals(externalLocation)) {
+					// when updating external events, we need to set up again start and end dates
+					eventManager.setStartTime(start).setEndTime(end).setLocation(externalLocation).complete();
+					updated = true;
+				}
+			}
+			if (event.getStartTime().compareTo(start) != 0) {
+				eventManager.setStartTime(start).complete();
+				updated = true;
+			}
+			if (event.getEndTime().compareTo(end) != 0) {
+				eventManager.setEndTime(end).complete();
+				updated = true;
+			}
+
+			if (updated) {
+				System.out.println("Event updated : " + title);
+			} 
+			return;
+		}
+		
+		if (channel != null)
+			guild.createScheduledEvent(title, channel, start).setDescription(description).setEndTime(end).complete();
+		else
+			guild.createScheduledEvent(title, externalLocation, start, end).setDescription(description).complete();
+		System.out.println("Event created : " + title);
+		 
+	}
+
+	protected static OffsetDateTime timestampToOffsetDateTime(Long ts) {
+		/* Convert Timestamp object to OffsetDateTime object */
+		Timestamp timestamp = new Timestamp(ts);
+        LocalDateTime localDateTime = timestamp.toLocalDateTime();
+        ZoneOffset systemZoneOffset = ZoneId.systemDefault().getRules().getOffset(Instant.now());
+        return localDateTime.atOffset(systemZoneOffset);
+	}
+
+
+	protected static boolean isCongressusEvent(JSONArray congressusMeetings, long id) {
+		/* Check on array if there is a meeting with this id */
+		for(int i = 0; i < congressusMeetings.length(); ++i) {
+			JSONObject meeting = congressusMeetings.getJSONObject(i);
+			if (meeting.getLong("id") == id)
+				return true;
+		}
+		return false;
+	}
+
+	protected static long extractIdFromDescription(String description) {
+		/* Extract ID on url from description */
+
+		String regex = "https://(.+)id=([0-9]+)(.*)";
+		Pattern p = Pattern.compile(regex);
+		for (String part: description.split("\\s")) {
+			try {
+				Matcher m = p.matcher(part);
+				if (m.matches()) {
+					long id = Long.parseLong(m.group(2));
+					return id;
+				}
+			} catch (Exception e) {}
+		}
+		return -1;
+	}
+
+	protected static void deleteOldEvents(JSONArray congressusMeetings, List<ScheduledEvent> discordEvents, Guild guild) {
+		/* Delete discord events that have congressus url on description but not on current meetings */
+		
+		String baseUrl = CongressusHelper.getUrl();
+
+		for (ScheduledEvent event : discordEvents) {
+			String description = event.getDescription();
+			if (description.contains(baseUrl)) {
+				long id = extractIdFromDescription(description);
+				if (id > 0) {
+					if (!isCongressusEvent(congressusMeetings, id)) {
+						//System.out.println("Discord event '" + event.getName() + "' points to unknown Congressus meeting id " + id);
+						event.delete().complete();
+					}
+				} else {
+					System.out.println("Unable to find id on event " + event.getName());
+				}
+			}
+		}
+	}
+
+}

--- a/java-project/src/fr/partipirate/discord/bots/congressus/listeners/SyncAgendaHandler.java
+++ b/java-project/src/fr/partipirate/discord/bots/congressus/listeners/SyncAgendaHandler.java
@@ -1,0 +1,62 @@
+package fr.partipirate.discord.bots.congressus.listeners;
+
+import fr.partipirate.discord.bots.congressus.Configuration;
+import fr.partipirate.discord.bots.congressus.CongressusBot;
+import fr.partipirate.discord.bots.congressus.common.congressus.SyncAgenda;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+public class SyncAgendaHandler extends ListenerAdapter {
+    private static long DELAY = 3600000L; // 60mn, by default
+	private static SyncAgendaHandler INSTANCE;
+	private CongressusBot congressusBot;
+
+    public SyncAgendaHandler(CongressusBot congressusBot) {
+		this.congressusBot = congressusBot;
+
+		if (Configuration.getInstance().OPTIONS.get("syncAgenda") != null) {
+			String delayString = Configuration.getInstance().OPTIONS.get("syncAgenda").get("delay");
+			if (delayString != null) {
+				DELAY = Integer.parseInt(delayString);
+			}
+		}
+		System.out.println("Scheduling SyncAgenda every " + (DELAY/1000) + " seconds");
+
+		launchSchedulerThread();
+		
+		INSTANCE = this;
+	}
+
+    public static SyncAgendaHandler getInstance() {
+		return INSTANCE;
+	}
+
+	private void launchSchedulerThread() {
+		Thread syncAgendaThread = new Thread() {
+			@Override
+			public void run() {
+				while (true) { // check the bot connection status
+					synchronized (this) {
+						try {
+							syncAgenda();
+							this.wait(DELAY);
+						} 
+						catch (InterruptedException e) {
+							e.printStackTrace();
+						}
+					}
+				}
+			}
+		};
+		syncAgendaThread.start();
+	}
+
+    private void syncAgenda() {
+		if (congressusBot.getJDA() != null) {
+			// needed to check if bot is initialized
+        	System.out.println("Syncing agenda");
+        	for(Guild guild : congressusBot.getJDA().getGuilds())
+            	SyncAgenda.syncAgenda(guild);
+		}
+    }
+}


### PR DESCRIPTION
Ajout d'une fonctionnalité pour synchroniser les meetings Congressus avec l'agenda des événements Discord.

2 manières de lancer la synchro : 
- via la commande `!agenda` dans la classe `fr.partipirate.discord.bots.congressus.commands.congressus.SyncAgendaCommand`
- via le listener périodique dans la classe `fr.partipirate.discord.bots.congressus.listeners.SyncAgendaHandler`

le listener est programmé par défaut toutes les heures, le paramètre peut être modifié dans le fichier de conf (en ms)

le code principal de synchro est dans la classe `fr.partipirate.discord.bots.congressus.common.congressus.SyncAgenda`

Afin d'identifier un événement, et de suivre les éventuelles modifications, celui-ci contient l'url de congressus dans sa description.
La synchro est faite de manière suivante : 
- on récupère les meetings de congressus ainsi que la liste des événements discord
- pour chaque meeting, on regarde si il y a un event ayant l'url de congressus dans sa description
  - si non, on crée l'événement
  - si oui, on vérifie que le titre, la description, le lieu et les heures sont bonnes, si ce n'est pas le cas, on update l'événement
- pour chaque événement discord, on regarde si il a une url de congressus
  - si oui, on regarde si on a toujours un meeting à cette url, dans le cas contraire, on supprime l'événement discord (dans le cas où un meeting aurait été annulé coté congressus)


Chaque événement discord est construit de la manière suivante
- le titre correspond au `meetingTitle` congressus (un titre court)
- la description correspond au titre complet, à l'information de la localisation (avec extra si disponible), et à l'url du meeting dans Congressus
- le lieu correspond au chan discord si il a été trouvé, ou à la description de la localisation si elle existe
- les dates de début et de fin sont définies à celles inscrites dans Congressus

Note: Discord ne permet pas de créer un événement ayant une date de début dans le passé (cas pour les événements déjà en cours), ceux-ci sont donc ignorés, donc une modification de meeting dans congressus pour un événement déjà commencé ne sera pas pris en compte.